### PR TITLE
Additional RuleEngine and Fact validation checks, testing, and documentation corrections

### DIFF
--- a/.github/prompts/Editorial Review.prompt.md
+++ b/.github/prompts/Editorial Review.prompt.md
@@ -1,11 +1,11 @@
 You are a professional technical documentation editor.
 
-Review the provided document(s) and provide corrections ensuring the following:
-* Grammatical and spelling correctness
-* Consistency of voice and tense
-* Consistency in professional writing style
-* Accuracy of technical content
+Review the attached document(s) and perform these editorial tasks:
+* Correct grammar and spelling
+* Observe the writing tone and style and ensure consistency throughout the document(s)
+* Review the content for factual and technical accuracy
 
-While you may change the content as needed, do not:
-* Modify any markdown structure present
-* Add editorial comments to the document
+While editing the document(s), you must not violate these rules:
+* Do not modify any markdown structure present
+* Do not modify code (but you may correct existing code comments and strings intended for humans to read)
+* Do not add any editorial comments to the document(s)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.1.0" # Update manually, or use plugin
+version = "1.1.1" # Update manually, or use plugin
 packages = [{ include = "vulcan_core", from="src" }]
 requires-poetry = "~2.1.1"
 classifiers = [

--- a/src/vulcan_core/ast_utils.py
+++ b/src/vulcan_core/ast_utils.py
@@ -24,7 +24,7 @@ class ContractError(Exception):
 
 class ScopeAccessError(ContractError):
     """Raised when a callable attempts to access instances not passed as parameters or when decorated functions attempt
-    a toccess class attributes instead of parameter instance attributes ."""
+    to access class attributes instead of parameter instance attributes."""
 
 
 class NotAFactError(ContractError):

--- a/src/vulcan_core/conditions.py
+++ b/src/vulcan_core/conditions.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True, slots=True)
 class Expression(DeclaresFacts):
     """
-    Abstract base class for defining deferred logical expressions. It captures the assosciation of logic with Facts so
+    Abstract base class for defining deferred logical expressions. It captures the association of logic with Facts so
     that upon a Fact update, the logical expression can be selectively evaluated. It also provides a set of logical
     operators for combining conditions, resulting in a new CompoundCondition.
     """
@@ -63,7 +63,7 @@ class Expression(DeclaresFacts):
 @dataclass(frozen=True, slots=True)
 class Condition(FactHandler[ConditionCallable, bool], Expression):
     """
-    A Condition is a container to defer logical epxressions against a supplied Fact. The expression can be inverted
+    A Condition is a container to defer logical expressions against a supplied Fact. The expression can be inverted
     using the `~` operator. Conditions also support the '&',  '|', and '^' operators for combinatorial logic.
 
     Attributes:

--- a/src/vulcan_core/engine.py
+++ b/src/vulcan_core/engine.py
@@ -115,17 +115,18 @@ class RuleEngine:
         else:
             self._facts[type(fact).__name__] = fact
 
-    def rule[T: Fact](self, *, name: str | None = None, when: Expression, then: Action, inverse: Action | None = None):
+    def rule[T: Fact](self, *, name: str | None = None, when: Expression, then: Action, inverse: Action | None = None) -> None:
         """
         Convenience method for adding a rule to the rule engine.
 
         Args:
-          name (Optional[str]): The name of the rule. Defaults to None.
-          when (Expression): The condition that triggers the rule.
-          then (Action): The action to be executed when the condition is met.
-          inverse (Optional[Action]): The action to be executed when the condition is not met. Defaults to None.
+            name (Optional[str]): The name of the rule. Defaults to None.
+            when (Expression): The condition that triggers the rule.
+            then (Action): The action to be executed when the condition is met.
+            inverse (Optional[Action]): The action to be executed when the condition is not met. Defaults to None.
 
-        Returns: None
+        Returns:
+            None
         """
         rule = Rule(name, when, then, inverse)
 

--- a/src/vulcan_core/models.py
+++ b/src/vulcan_core/models.py
@@ -120,7 +120,7 @@ class FactMetaclass(type):
 
 class Fact(ImmutableAttrAsDict, metaclass=FactMetaclass):
     """
-    An abstract class that must be used define rule engine fact schemas and instantiate data into working memory. Facts
+    An abstract class that must be used to define rule engine fact schemas and instantiate data into working memory. Facts
     may be combined with partial facts of the same type using the `|` operator. This is useful for Actions that only
     need to update a portion of working memory.
 

--- a/src/vulcan_core/models.py
+++ b/src/vulcan_core/models.py
@@ -133,8 +133,16 @@ class Fact(ImmutableAttrAsDict, metaclass=FactMetaclass):
         lefthand operand is created with the partial Fact's keywords applied.
         """
         if isinstance(other, Fact):
+            if type(self) is not type(other):
+                msg = f"Union operator disallowed for types {type(self).__name__} and {type(other).__name__}"
+                raise TypeError(msg)
+
             return other  # type: ignore
         else:
+            if type(self) is not other.func:
+                msg = f"Union operator disallowed for types {type(self).__name__} and {other.func}"
+                raise TypeError(msg)
+
             new_fact = copy(self)
             for kw, value in other.keywords.items():
                 object.__setattr__(new_fact, kw, value)

--- a/src/vulcan_core/util.py
+++ b/src/vulcan_core/util.py
@@ -11,7 +11,7 @@ from typing import Any, NoReturn
 
 @dataclass(frozen=True)
 class WithContext:
-    """Applys a context manager as a decorator.
+    """Applies a context manager as a decorator.
 
     @WithContext(suppress(Exception))
         def foo():

--- a/tests/core/test_conditions.py
+++ b/tests/core/test_conditions.py
@@ -9,6 +9,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_openai import ChatOpenAI
 
 from vulcan_core import Condition, Fact, MissingFactError, condition
+from vulcan_core.ast_utils import CallableSignatureError
 from vulcan_core.conditions import ai_condition
 
 
@@ -142,3 +143,8 @@ def test_aicondition_model_override():
     cond2 = custom_condition(f"Are {FactA.feature} and {FactB.feature} both on the same planet?", model=model2)
 
     assert cond1.model != cond2.model  # type: ignore
+
+
+def test_lambda_param_check():
+    with pytest.raises(CallableSignatureError):
+        condition(lambda x: Foo.baz)

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2025 Latchfield Technologies http://latchfield.com
 
+from dataclasses import dataclass
 from functools import partial
 
 import pytest
 
 from vulcan_core import Fact, InternalStateError, RecursionLimitError, RuleEngine, action, condition
+from vulcan_core.ast_utils import NotAFactError
 
 
 class Foo(Fact):
@@ -205,6 +207,17 @@ def test_initialize_fact_autocreate():
     result = engine[Foo]
     assert result.baz is False
     assert result.bol is True
+
+
+def test_not_a_fact():
+    @dataclass()
+    class NotAFact:
+        some_value: int = 0
+
+    engine = RuleEngine()
+
+    with pytest.raises(NotAFactError):
+        engine.fact(NotAFact())  # type: ignore
 
 
 @pytest.mark.integration

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -5,6 +5,7 @@ import _string  # type: ignore
 import inspect
 import string
 from dataclasses import dataclass, field
+from functools import partial
 
 import pytest
 from langchain.schema import Document
@@ -111,3 +112,31 @@ def test_format2():
     d = {"a": 1, "b": ProxyLazyLookup()}
     s = "{a} {b.c}"
     DeferredFormatter().vformat(s, [], d)
+
+
+def test_union_incompatible_facts():
+    class Foo(Fact):
+        foo: str
+
+    class Bar(Fact):
+        bar: str
+        baz: int = 0
+
+    foo = Foo(foo="foo")
+    bar = Bar(bar="bar")
+
+    with pytest.raises(TypeError):
+        foo | bar  # type: ignore
+
+def test_union_incompatible_partial_facts():
+    class Foo(Fact):
+        foo: str
+
+    class Bar(Fact):
+        bar: str
+        baz: int = 0
+
+    foo = Foo(foo="foo")
+
+    with pytest.raises(TypeError):
+        foo | partial(Bar, baz=1)  # type: ignore        


### PR DESCRIPTION
<!---
Thank you for your contribution!

To ensure the best experience for users, your fellow contributors, and yourself, please follow this template carefully to ensure your pull request meets contribution guidelines. If you have any questions or comments, please don't hesitate to reach out in the project discussions tab at the top of this page.
--->

## Pull Request Checklist
<!--- All items must be checked [X] to accept your contribution: -->
- [X] I agree to the [developers certificate of origin](https://developercertificate.org/).
- [X] I have cryptographically signed all of my commits. [[signing instructions]](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [X] I have updated the pull-request title to be short, clear, and descriptive.
- [ ] ~I have created, or I am referencing, a reported issue describing the feature/bug/contribution in detail.~
- [ ] ~I have scoped my PR to a single logical feature/bug/contribution.~ <!-- It's okay if your PR resolves multiple related issues, but please avoid creating PRs with multiple unrelated contributions. -->

### Optional Checklist Items
<!-- These are highly appreciated items, but not everyone may find them easy to perform. -->
- [x] I have created a dedicated branch for this PR in my fork to avoid accidental updates to this PR.
- [x] I have squashed my commit history on my branch to keep the history tidy.
- [ ] I have used git `--signoff` to record my agreement with the developers certificate of origin.

## Summary of Contribution
<!-- Please summarize in bulleted form, what your contribution adds or changes in the project. -->
- Added additional runtime validation for non-Fact type operations in `RulesEngine` and Fact union operator. These were previously only caught with static type checking.
- Added unit tests to catch regression of missing validation checks of non-Fact types.
- Corrected spelling and grammar in various documents