### PR TITLE
Fix for AICondition inversion error

### DIFF
--- a/src/vulcan_core/conditions.py
+++ b/src/vulcan_core/conditions.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import _string  # type: ignore
 import re
 from abc import abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum, auto
 from functools import lru_cache
 from string import Formatter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from langchain.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
@@ -78,8 +78,8 @@ class Condition(FactHandler[ConditionCallable, bool], Expression):
         result = self.func(*args)
         return not result if self.inverted else result
 
-    def __invert__(self) -> Condition:
-        return Condition(self.facts, self.func, inverted=not self.inverted)
+    def __invert__(self) -> Self:
+        return replace(self, inverted=not self.inverted)
 
 
 class Operator(Enum):

--- a/tests/core/test_conditions.py
+++ b/tests/core/test_conditions.py
@@ -232,6 +232,15 @@ def test_ai_simple_condition_true(fact_a_instance: FactA, fact_b_instance: FactB
     assert cond(fact_a_instance, fact_b_instance) is True
 
 
+# https://github.com/latchfield/vulcan-core/issues/68
+@pytest.mark.integration
+def test_ai_inverted_condition(fact_a_instance: FactA, fact_b_instance: FactB):
+    cond = ~condition(f"Are {FactA.feature} and {FactB.feature} both on the same planet?")
+
+    assert set(cond.facts) == {"FactA.feature", "FactB.feature"}
+    assert cond(fact_a_instance, fact_b_instance) is True
+
+
 @pytest.mark.integration
 def test_ai_missing_fact():
     # TODO: Determine the difference between tool calls and non-tool calls


### PR DESCRIPTION
<!---
Thank you for your contribution!

To ensure the best experience for users, your fellow contributors, and yourself, please follow this template carefully to ensure your pull request meets contribution guidelines. If you have any questions or comments, please don't hesitate to reach out in the project discussions tab at the top of this page.
--->

## Pull Request Checklist
<!--- All items must be checked [X] to accept your contribution: -->
- [X] I agree to the [developers certificate of origin](https://developercertificate.org/).
- [X] I have cryptographically signed all of my commits. [[signing instructions]](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [X] I have updated the pull-request title to be short, clear, and descriptive.
- [X] I have created, or I am referencing, a reported issue describing the feature/bug/contribution in detail.
- [X] I have scoped my PR to a single logical feature/bug/contribution. <!-- It's okay if your PR resolves multiple related issues, but please avoid creating PRs with multiple unrelated contributions. -->

<!-- Please list the issue number(s) that your PR is meant to resolve. E.g. "resolves #10 #11" -->
My PR resolves #68

### Optional Checklist Items
<!-- These are highly appreciated items, but not everyone may find them easy to perform. -->
- [X] I have created a dedicated branch for this PR in my fork to avoid accidental updates to this PR.
- [X] I have squashed my commit history on my branch to keep the history tidy.
- [ ] I have used git `--signoff` to record my agreement with the developers certificate of origin.

## Summary of Contribution
<!-- Please summarize in bulleted form, what your contribution adds or changes in the project. -->
- add test for inverted AI condition

## Additional Information
<!-- Enter below any other information you feel is important in reviewing this contribution (screenshots, detailed thoughts, etc.). Avoid duplicating information already present in the referenced issue numbers. -->