### PR TITLE
Improved resliency of lambda parsing and argument extraction

### DIFF
--- a/src/vulcan_core/conditions.py
+++ b/src/vulcan_core/conditions.py
@@ -111,7 +111,21 @@ class CompoundCondition(Expression):
 
     def _pick_args(self, expr: Expression, args) -> list[Fact]:
         """Returns the arg values passed to this CompoundCondition that are needed by the given expression."""
-        return [arg for fact, arg in zip(self.facts, args, strict=False) if fact in expr.facts]
+        # Extract required class types from expression facts
+        required_types = set()
+        for fact in expr.facts:
+            class_name = fact.split('.')[0]  # Extract class name from "ClassName.attribute"
+            required_types.add(class_name)
+        
+        # Find matching instances from args by class type
+        result = []
+        for class_name in sorted(required_types):  # Sort for consistent ordering
+            for arg in args:
+                if arg.__class__.__name__ == class_name:
+                    result.append(arg)
+                    break
+        
+        return result
 
     def __call__(self, *args: Fact) -> bool:
         """

--- a/src/vulcan_core/conditions.py
+++ b/src/vulcan_core/conditions.py
@@ -114,17 +114,17 @@ class CompoundCondition(Expression):
         # Extract required class types from expression facts
         required_types = set()
         for fact in expr.facts:
-            class_name = fact.split('.')[0]  # Extract class name from "ClassName.attribute"
+            class_name = fact.split(".")[0]  # Extract class name from "ClassName.attribute"
             required_types.add(class_name)
-        
+
         # Find matching instances from args by class type
         result = []
-        for class_name in sorted(required_types):  # Sort for consistent ordering
+        for class_name in required_types:
             for arg in args:
                 if arg.__class__.__name__ == class_name:
                     result.append(arg)
                     break
-        
+
         return result
 
     def __call__(self, *args: Fact) -> bool:

--- a/tests/core/test_conditions.py
+++ b/tests/core/test_conditions.py
@@ -126,6 +126,24 @@ def test_invert_condition(foo_instance: Foo):
     assert inverted(foo_instance) == (not cond(foo_instance))
 
 
+# https://github.com/latchfield/vulcan-core/issues/65  
+def test_multiline_compound_condition_with_lambda(foo_instance: Foo, bar_instance: Bar):
+    cond1 = condition(lambda: Foo.baz)
+    cond2 = condition(lambda: Bar.biz)
+
+    assert cond1(foo_instance) is True
+    assert cond2(bar_instance) is False  # Bar.biz is False by default
+    
+    # fmt: off
+    compound_cond = (cond1
+                   & cond2
+                   & condition(lambda: Foo.baz or Bar.biz))
+    # fmt: on
+
+    result = compound_cond(foo_instance, bar_instance)
+    assert result is False
+
+
 # https://github.com/latchfield/vulcan-core/issues/30
 def test_short_circuit_condition(foo_instance: Foo):
     true_condition = condition(lambda: True)

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -93,6 +93,50 @@ def test_same_fact_multiple_attributes_lambda(engine: RuleEngine):
     assert engine[Bar].biz is True
 
 
+# https://github.com/latchfield/vulcan-core/issues/65
+def test_multiline_rule(engine: RuleEngine):
+    cond1 = condition(lambda: Foo.baz)
+    cond2 = condition(lambda: Foo.bol)
+
+    # fmt: off
+    engine.rule(
+        when=cond1
+        & cond2
+        & condition(lambda: Foo.baz or Foo.bol or Foo.baz),
+        then=action(partial(Bar, biz=True)),
+    )
+    # fmt: on
+
+    engine.evaluate()
+    assert engine[Bar].biz is True
+
+
+# https://github.com/latchfield/vulcan-core/issues/65
+def test_rule_with_reserved_literals(engine: RuleEngine):
+    # fmt: off
+    engine.rule(
+        when=condition(lambda: Foo.bol)
+        & condition(lambda: "lambda:" != None) & condition(lambda: Foo.baz),
+        then=action(partial(Bar, biz=True)),
+    )
+    # fmt: on
+
+    engine.evaluate()
+    assert engine[Bar].biz is True
+
+
+# https://github.com/latchfield/vulcan-core/issues/66
+def test_same_fact_multiple_attributes_compound_conditions(engine: RuleEngine):
+    # Suspect there may be a random component somewhere - sometimes this test passes when expected to fail
+    engine.rule(
+        when=condition(lambda: Foo.baz) & condition(lambda: Foo.bol),
+        then=action(partial(Bar, biz=True)),
+    )
+
+    engine.evaluate()
+    assert engine[Bar].biz is True
+
+
 def test_same_fact_multiple_attributes_decorator(engine: RuleEngine):
     @condition
     def cond(foo: Foo) -> bool:


### PR DESCRIPTION
<!---
Thank you for your contribution!

To ensure the best experience for users, your fellow contributors, and yourself, please follow this template carefully to ensure your pull request meets contribution guidelines. If you have any questions or comments, please don't hesitate to reach out in the project discussions tab at the top of this page.
--->

## Pull Request Checklist
<!--- All items must be checked [X] to accept your contribution: -->
- [x] I agree to the [developers certificate of origin](https://developercertificate.org/).
- [x] I have cryptographically signed all of my commits. [[signing instructions]](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] I have updated the pull-request title to be short, clear, and descriptive.
- [x] I have created, or I am referencing, a reported issue describing the feature/bug/contribution in detail.
- [x] I have scoped my PR to a single logical feature/bug/contribution. <!-- It's okay if your PR resolves multiple related issues, but please avoid creating PRs with multiple unrelated contributions. -->

<!-- Please list the issue number(s) that your PR is meant to resolve. E.g. "resolves #10 #11" -->
My PR resolves #65 and resolves #66 

### Optional Checklist Items
<!-- These are highly appreciated items, but not everyone may find them easy to perform. -->
- [x] I have created a dedicated branch for this PR in my fork to avoid accidental updates to this PR.
- [x] I have squashed my commit history on my branch to keep the history tidy.
- [ ] I have used git `--signoff` to record my agreement with the developers certificate of origin.

## Summary of Contribution
<!-- Please summarize in bulleted form, what your contribution adds or changes in the project. -->
- Improved resliency of lambda parsing and argument extraction
- Added test cases
- Refactored AST utils to use Python language tokenizer for lambda extraction operations

## Additional Information
None